### PR TITLE
remove extraneous arguments to use_ok

### DIFF
--- a/t/01ffo.t
+++ b/t/01ffo.t
@@ -12,7 +12,7 @@ use File::Path qw(rmtree);
 use Test::File 1.993 ();
 
 # TEST
-use_ok( 'File::Find::Object', "Can use main File::Find::Object" );
+use_ok( 'File::Find::Object' );
 
 mkdir('t/dir');
 mkdir('t/dir/a');


### PR DESCRIPTION
The extra arguments to use_ok are arguments passed to the module's import method, not a test name. Newer perl versions will reject import calls with unhandled arguments, causing a failure.